### PR TITLE
Replace Perl generators with Python

### DIFF
--- a/gen_common_h.py
+++ b/gen_common_h.py
@@ -1,0 +1,81 @@
+import ast
+
+INPUT_FILE = 'input/andla_common.tmp.h'
+OUTPUT_FILE = 'output/andla_common.h'
+REG_FILE = 'output/regfile_dictionary.log'
+
+def parse_entries():
+    entries = []
+    with open(REG_FILE) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            processed = line.replace(': nan', ': None')
+            entries.append(ast.literal_eval(processed))
+    return entries
+
+
+def bitwidth_from_loc(loc):
+    if not loc:
+        return 0
+    if '[' in loc and ':' in loc:
+        loc = loc.split('~')[0].strip()
+        hi, lo = loc.strip('[]').split(':')
+        return int(hi) - int(lo) + 1
+    return 1
+
+
+def gen_lines(entries):
+    lines = []
+    for d in entries:
+        item = d['Item']
+        reg = d['Register']
+        sub = d['SubRegister']
+        idx_name = f"{item}_{reg}"
+        if sub and sub not in [None, 'nan'] and sub not in ['LSB','MSB']:
+            idx_name = f"{item}_{reg}_{sub}"
+        bitwidth = bitwidth_from_loc(d.get('Bit Locate'))
+        lines.append(f"    reg_file->item[{item}].reg[{idx_name}].bitwidth\n  = {bitwidth};")
+        lines.append(f"    reg_file->item[{item}].reg[{idx_name}].index\n  = {idx_name};\n")
+    return lines
+
+
+def gen_item_init(entries):
+    seen = set()
+    lines = []
+    for d in entries:
+        item = d['Item']
+        if item in seen:
+            continue
+        seen.add(item)
+        lines.append(f"    reg_file->item[{item}].id\n  = {item};")
+        lc = item.lower()
+        lines.append(f"    reg_file->item[{item}].base_addr_ptr\n  = andla_{lc}_reg_p;")
+        lines.append(f"    reg_file->item[{item}].reg_num\n  = 0;\n")
+    return lines
+
+
+def main():
+    entries = parse_entries()
+    auto_lines = gen_lines(entries)
+    item_lines = gen_item_init(entries)
+
+    with open(INPUT_FILE) as fin, open(OUTPUT_FILE,'w') as fout:
+        in_auto = False
+        for line in fin:
+            if line.strip() == '// autogen_start':
+                fout.write(line)
+                for l in auto_lines:
+                    fout.write(l + "\n")
+                in_auto = True
+            elif in_auto and line.strip() == '// autogen_stop':
+                for l in item_lines:
+                    fout.write(l + "\n")
+                fout.write(line)
+                in_auto = False
+            elif not in_auto:
+                fout.write(line)
+
+if __name__ == '__main__':
+    main()

--- a/gen_h.py
+++ b/gen_h.py
@@ -1,0 +1,235 @@
+import ast
+from collections import OrderedDict
+
+INPUT_FILE = 'input/andla.tmp.h'
+OUTPUT_FILE = 'output/andla.h'
+REG_FILE = 'output/regfile_dictionary.log'
+
+
+def parse_entries():
+    entries = []
+    with open(REG_FILE) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            processed = line.replace(': nan', ': None')
+            entries.append(ast.literal_eval(processed))
+    return entries
+
+
+def gen_idx(entries):
+    idx_entries = []
+    current_item = None
+    buffer = []
+    seen = set()
+    for d in entries:
+        item = d.get('Item')
+        reg = d.get('Register')
+        sub = d.get('SubRegister')
+        entry = f"{item}_{reg}"
+        if sub in ('LSB', 'MSB'):
+            entry += f"_{sub}"
+        if item != current_item:
+            if buffer:
+                idx_entries.append("SMART_ENUM(" + current_item + "\n" + "\n".join(buffer) + "\n);")
+                buffer = []
+            current_item = item
+            seen = set()
+        if entry in seen:
+            continue
+        seen.add(entry)
+        buffer.append(f"    ,{entry}")
+    if buffer:
+        idx_entries.append("SMART_ENUM(" + current_item + "\n" + "\n".join(buffer) + "\n);")
+    return idx_entries
+
+
+def gen_reg(entries):
+    reg_entries = []
+    current_item = None
+    buffer = []
+    seen = set()
+    for d in entries:
+        item = d['Item']
+        reg = d['Register']
+        sub = d['SubRegister']
+        name = reg.lower()
+        if sub in ('LSB', 'MSB'):
+            name += '_' + sub.lower()
+        key = (item, name)
+        if item != current_item:
+            if buffer:
+                item_lc = current_item.lower()
+                reg_entries.append(f"typedef struct andla_{item_lc}_reg_t {{\n" + "\n".join(buffer) + f"\n}} andla_{item_lc}_reg_s;")
+                buffer = []
+            current_item = item
+            seen = set()
+        if name in seen:
+            continue
+        seen.add(name)
+        buffer.append(f"    __IO uint32_t {name};")
+    if buffer:
+        item_lc = current_item.lower()
+        reg_entries.append(f"typedef struct andla_{item_lc}_reg_t {{\n" + "\n".join(buffer) + f"\n}} andla_{item_lc}_reg_s;")
+    return reg_entries
+
+
+def gen_base(entries):
+    base_entries = []
+    seen = set()
+    for d in entries:
+        item = d['Item']
+        if item in seen:
+            continue
+        seen.add(item)
+        base = d.get('Physical Address', '0')
+        subbase = base[-3:]
+        base_entries.append(f"#define ANDLA_{item}_REG_BASE (ANDLA_REG_BASE + 0x{subbase})")
+    return base_entries
+
+
+def gen_dest(entries):
+    dest_entries = []
+    item_ids = []
+    seen = set()
+    for d in entries:
+        item = d['Item']
+        if item in seen:
+            continue
+        seen.add(item)
+        item_ids.append((int(d.get('ID',0)), item))
+    item_ids.sort()
+    current_id = -1
+    for id_val, item in item_ids:
+        while current_id + 1 < id_val:
+            current_id += 1
+            dest_entries.append(f"#define RESERVED_{current_id}_DEST               (0x1 <<  {current_id})")
+        dest_entries.append(f"#define {item}_DEST               (0x1 <<  {id_val})")
+        current_id = id_val
+    return dest_entries
+
+
+def gen_item_enum(entries):
+    item_ids = []
+    seen = set()
+    for d in entries:
+        item = d['Item']
+        if item in seen:
+            continue
+        seen.add(item)
+        item_ids.append((int(d.get('ID',0)), item))
+    item_ids.sort()
+    lines = ["SMART_ENUM(ITEM"]
+    current_id = -1
+    for id_val, item in item_ids:
+        while current_id + 1 < id_val:
+            current_id += 1
+            lines.append(f"   ,RESERVED_{current_id}")
+        lines.append(f"   ,{item}")
+        current_id = id_val
+    lines.append(");")
+    return lines
+
+
+def gen_devreg(entries):
+    dev_entries = []
+    seen = set()
+    for d in entries:
+        item = d['Item']
+        if item in seen:
+            continue
+        seen.add(item)
+        lc = item.lower()
+        dev_entries.append(f"#define DEV_ANDLA_{item}_REG     ((andla_{lc}_reg_s*)      ANDLA_{item}_REG_BASE  )")
+    return dev_entries
+
+
+def gen_extreg(entries):
+    ext_entries = []
+    seen = set()
+    for d in entries:
+        item = d['Item']
+        if item in seen:
+            continue
+        seen.add(item)
+        lc = item.lower()
+        ext_entries.append(f"extern andla_{lc}_reg_s        *andla_{lc}_reg_p;")
+    return ext_entries
+
+
+def main():
+    entries = parse_entries()
+    idx_entries = gen_idx(entries)
+    reg_entries = gen_reg(entries)
+    base_entries = gen_base(entries)
+    dest_entries = gen_dest(entries)
+    item_entries = gen_item_enum(entries)
+    devreg_entries = gen_devreg(entries)
+    extreg_entries = gen_extreg(entries)
+
+    with open(INPUT_FILE) as fin, open(OUTPUT_FILE, 'w') as fout:
+        in_idx = in_reg = in_base = in_dest = in_item = in_dev = in_ext = False
+        for line in fin:
+            if line.strip() == '// autogen_idx_start':
+                fout.write(line)
+                for l in idx_entries:
+                    fout.write(l + "\n")
+                in_idx = True
+            elif in_idx and line.strip() == '// autogen_idx_stop':
+                fout.write(line)
+                in_idx = False
+            elif line.strip() == '// autogen_reg_start':
+                fout.write(line)
+                for l in reg_entries:
+                    fout.write(l + "\n")
+                in_reg = True
+            elif in_reg and line.strip() == '// autogen_reg_stop':
+                fout.write(line)
+                in_reg = False
+            elif line.strip() == '// autogen_base_start':
+                fout.write(line)
+                for l in base_entries:
+                    fout.write(l + "\n")
+                in_base = True
+            elif in_base and line.strip() == '// autogen_base_stop':
+                fout.write(line)
+                in_base = False
+            elif line.strip() == '// autogen_dest_start':
+                fout.write(line)
+                for l in dest_entries:
+                    fout.write(l + "\n")
+                in_dest = True
+            elif in_dest and line.strip() == '// autogen_dest_stop':
+                fout.write(line)
+                in_dest = False
+            elif line.strip() == '// autogen_item_start':
+                fout.write(line)
+                for l in item_entries:
+                    fout.write(l + "\n")
+                in_item = True
+            elif in_item and line.strip() == '// autogen_item_stop':
+                fout.write(line)
+                in_item = False
+            elif line.strip() == '// autogen_devreg_start':
+                fout.write(line)
+                for l in devreg_entries:
+                    fout.write(l + "\n")
+                in_dev = True
+            elif in_dev and line.strip() == '// autogen_devreg_stop':
+                fout.write(line)
+                in_dev = False
+            elif line.strip() == '// autogen_extreg_start':
+                fout.write(line)
+                for l in extreg_entries:
+                    fout.write(l + "\n")
+                in_ext = True
+            elif in_ext and line.strip() == '// autogen_extreg_stop':
+                fout.write(line)
+                in_ext = False
+            else:
+                if not any([in_idx, in_reg, in_base, in_dest, in_item, in_dev, in_ext]):
+                    fout.write(line)
+    
+if __name__ == '__main__':
+    main()

--- a/gen_map.py
+++ b/gen_map.py
@@ -1,0 +1,59 @@
+import ast
+
+INPUT_FILE = 'input/regfile_map.tmp.h'
+OUTPUT_FILE = 'output/regfile_map.h'
+REG_FILE = 'output/regfile_dictionary.log'
+
+
+def parse_entries():
+    entries = []
+    with open(REG_FILE) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            processed = line.replace(': nan', ': None')
+            entries.append(ast.literal_eval(processed))
+    return entries
+
+
+def gen_dest(entries):
+    dest_entries = []
+    item_ids = []
+    seen = set()
+    for d in entries:
+        item = d['Item']
+        if item in seen:
+            continue
+        seen.add(item)
+        item_ids.append((int(d.get('ID',0)), item))
+    item_ids.sort()
+    current_id = -1
+    for id_val, item in item_ids:
+        while current_id + 1 < id_val:
+            current_id += 1
+            dest_entries.append(f"#define RESERVED_{current_id}_DEST               (0x1 <<  {current_id})")
+        dest_entries.append(f"#define {item}_DEST               (0x1 <<  {id_val})")
+        current_id = id_val
+    return dest_entries
+
+
+def main():
+    entries = parse_entries()
+    dest_entries = gen_dest(entries)
+    with open(INPUT_FILE) as fin, open(OUTPUT_FILE, 'w') as fout:
+        in_dest = False
+        for line in fin:
+            if line.strip() == '// autogen_dest_start':
+                fout.write(line)
+                for l in dest_entries:
+                    fout.write(l + "\n")
+                in_dest = True
+            elif in_dest and line.strip() == '// autogen_dest_stop':
+                fout.write(line)
+                in_dest = False
+            elif not in_dest:
+                fout.write(line)
+
+if __name__ == '__main__':
+    main()

--- a/gen_regfile.py
+++ b/gen_regfile.py
@@ -1,0 +1,98 @@
+import ast
+
+INPUT_FILE = 'input/andla_regfile.tmp.v'
+OUTPUT_FILE = 'output/andla_regfile.v'
+REG_FILE = 'output/regfile_dictionary.log'
+
+def parse_entries():
+    entries = []
+    with open(REG_FILE) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            processed = line.replace(': nan', ': None')
+            entries.append(ast.literal_eval(processed))
+    return entries
+
+
+def unique_items(entries):
+    seen = set()
+    items = []
+    for d in entries:
+        item = d['Item']
+        if item not in seen:
+            seen.add(item)
+            items.append((int(d.get('ID',0)), item))
+    return sorted(items)
+
+
+def gen_port(entries):
+    ports = []
+    seen = set()
+    for d in entries:
+        item = d['Item'].lower()
+        reg = d['Register'].lower()
+        typ = str(d.get('Type','')).lower()
+        key = f"{item}_{reg}"
+        if key in seen:
+            continue
+        seen.add(key)
+        if item == 'csr' and (typ != 'rw' or reg in ['counter','counter_mask','status','control'] or reg.startswith('exram_based_addr')):
+            continue
+        ports.append(f", rf_{item}_{reg}")
+    return ports
+
+
+def gen_bitwidth(entries):
+    lines = []
+    seen = set()
+    for d in entries:
+        item = d['Item'].upper()
+        reg = d['Register'].upper()
+        sub = d['SubRegister']
+        key = (item, reg, sub)
+        if key in seen:
+            continue
+        seen.add(key)
+        if sub and sub not in [None,'nan']:
+            name = f"{item}_{reg}_{sub}_BITWIDTH"
+        else:
+            name = f"{item}_{reg}_BITWIDTH"
+        lines.append(f"localparam {name} = `{name};")
+    return lines
+
+
+def write_section(lines, start_tag, stop_tag, fout, active):
+    if active:
+        for l in lines:
+            fout.write(l + "\n")
+
+
+def main():
+    entries = parse_entries()
+    ports = gen_port(entries)
+    bitwidth_lines = gen_bitwidth(entries)
+    with open(INPUT_FILE) as fin, open(OUTPUT_FILE,'w') as fout:
+        in_port = in_bit = False
+        for line in fin:
+            if line.strip() == '// autogen_port_start':
+                fout.write(line)
+                write_section(ports, None, None, fout, True)
+                in_port = True
+            elif in_port and line.strip() == '// autogen_port_stop':
+                fout.write(line)
+                in_port = False
+            elif line.strip() == '// autogen_bitwidth_start':
+                fout.write(line)
+                write_section(bitwidth_lines, None, None, fout, True)
+                in_bit = True
+            elif in_bit and line.strip() == '// autogen_bitwidth_stop':
+                fout.write(line)
+                in_bit = False
+            else:
+                if not in_port and not in_bit:
+                    fout.write(line)
+
+if __name__ == '__main__':
+    main()

--- a/run.sh
+++ b/run.sh
@@ -2,10 +2,10 @@
 
 python3 csv2df.py
 python3 gen_vh.py
-perl gen_h.pl
-perl gen_common_h.pl
-perl gen_map.pl
-perl gen_regfile.pl
+python3 gen_h.py
+python3 gen_common_h.py
+python3 gen_map.py
+python3 gen_regfile.py
 python3 gen_reg_constraint_h.py
 
 # declare -A files=(


### PR DESCRIPTION
## Summary
- implement `gen_h.py`, `gen_common_h.py`, `gen_map.py`, `gen_regfile.py`
- switch `run.sh` to use the Python versions

## Testing
- `python3 gen_h.py`
- `python3 gen_common_h.py`
- `python3 gen_map.py`
- `python3 gen_regfile.py`

------
https://chatgpt.com/codex/tasks/task_e_686541fa9b848320b501eb0e5a20a1ee