### PR TITLE
Port perl scripts to Python

### DIFF
--- a/gen_common_h.py
+++ b/gen_common_h.py
@@ -1,0 +1,94 @@
+import ast
+
+INPUT_FILE = 'input/andla_common.tmp.h'
+OUTPUT_FILE = 'output/andla_common.h'
+REG_LOG = 'output/regfile_dictionary.log'
+TARGET_COL = 82
+
+
+def load_log():
+    entries = []
+    with open(REG_LOG) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            line = line.replace('nan', 'None')
+            entries.append(ast.literal_eval(line))
+    return entries
+
+
+def format_line(prefix, value):
+    spaces = max(1, TARGET_COL - len(prefix))
+    return prefix + (' ' * spaces) + '= ' + str(value) + ';\n'
+
+
+def bitwidth_from_loc(loc):
+    if loc and isinstance(loc, str):
+        import re
+        m = re.match(r'\[(\d+):(\d+)\]', loc)
+        if m:
+            h, l = int(m.group(1)), int(m.group(2))
+            return h - l + 1
+    return 0
+
+
+def build_sections(entries):
+    reg_lines = []
+    item_lines = []
+
+    seen_sub = set()
+    for e in entries:
+        item = e['Item']
+        reg = e['Register']
+        sub = e['SubRegister']
+        bitloc = e.get('Bit Locate')
+        bitwidth = bitwidth_from_loc(bitloc)
+        if isinstance(sub, str) and sub not in ('LSB','MSB'):
+            key = f"{item}_{reg}"
+            if key in seen_sub:
+                continue
+            seen_sub.add(key)
+        final_reg = f"{item}_{reg}" if not isinstance(sub, str) or sub in ('LSB','MSB') else f"{item}_{reg}_{sub}"
+        reg_name = final_reg
+        reg_lines.append(format_line(f"    reg_file->item[{item}].reg[{reg_name}].bitwidth", bitwidth))
+        reg_lines.append(format_line(f"    reg_file->item[{item}].reg[{reg_name}].index", reg_name))
+        reg_lines.append("\n")
+
+    seen_item = set()
+    for e in entries:
+        item = e['Item']
+        if item in seen_item:
+            continue
+        seen_item.add(item)
+        low_key = item.lower()
+        item_lines.append(format_line(f"    reg_file->item[{item}].id", item))
+        item_lines.append(format_line(f"    reg_file->item[{item}].base_addr_ptr", f"andla_{low_key}_reg_p"))
+        item_lines.append(format_line(f"    reg_file->item[{item}].reg_num", '0'))
+        item_lines.append("\n")
+
+    return reg_lines + item_lines
+
+
+def generate():
+    entries = load_log()
+    lines = build_sections(entries)
+    with open(INPUT_FILE) as fin, open(OUTPUT_FILE, 'w') as fout:
+        in_auto = False
+        for line in fin:
+            stripped = line.strip()
+            if stripped == '// autogen_start':
+                fout.write(line)
+                in_auto = True
+                for l in lines:
+                    fout.write(l)
+                continue
+            if stripped == '// autogen_stop':
+                in_auto = False
+                fout.write(line)
+                continue
+            if not in_auto:
+                fout.write(line)
+
+if __name__ == '__main__':
+    generate()

--- a/gen_h.py
+++ b/gen_h.py
@@ -1,0 +1,205 @@
+import ast
+
+INPUT_FILE = 'input/andla.tmp.h'
+OUTPUT_FILE = 'output/andla.h'
+REG_LOG = 'output/regfile_dictionary.log'
+
+
+def load_log():
+    entries = []
+    with open(REG_LOG) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            line = line.replace('nan', 'None')
+            entries.append(ast.literal_eval(line))
+    return entries
+
+
+def build_sections(entries):
+    idx_entries = []
+    reg_entries = []
+    base_entries = []
+    dest_entries = []
+    item_entries = ["SMART_ENUM(ITEM"]
+    devreg_entries = []
+    extreg_entries = []
+
+    # idx
+    current_item = None
+    buffer = []
+    seen = set()
+    for e in entries:
+        item = e['Item']
+        reg = e['Register']
+        sub = e['SubRegister']
+        entry = f"{item}_{reg}"
+        if isinstance(sub, str) and sub in ('LSB','MSB'):
+            entry += f"_{sub}"
+        if item != current_item:
+            if buffer:
+                idx_entries.append(f"SMART_ENUM({current_item}\n" + "\n".join(buffer) + "\n);\n")
+                buffer = []
+            current_item = item
+            seen.clear()
+        if entry in seen:
+            continue
+        seen.add(entry)
+        buffer.append(f"    ,{entry}")
+    if buffer:
+        idx_entries.append(f"SMART_ENUM({current_item}\n" + "\n".join(buffer) + "\n);\n")
+
+    # reg typedefs
+    current_item = None
+    buffer = []
+    seen.clear()
+    for e in entries:
+        item = e['Item']
+        reg = e['Register'].lower()
+        sub = e['SubRegister']
+        if isinstance(sub, str) and sub in ('LSB','MSB'):
+            reg += '_' + sub.lower()
+        if item != current_item:
+            if buffer:
+                item_lc = current_item.lower()
+                reg_entries.append(f"typedef struct andla_{item_lc}_reg_t {{\n" + "\n".join(buffer) + f"\n}} andla_{item_lc}_reg_s;\n")
+                buffer = []
+            current_item = item
+            seen.clear()
+        if reg in seen:
+            continue
+        seen.add(reg)
+        buffer.append(f"    __IO uint32_t {reg};")
+    if buffer:
+        item_lc = current_item.lower()
+        reg_entries.append(f"typedef struct andla_{item_lc}_reg_t {{\n" + "\n".join(buffer) + f"\n}} andla_{item_lc}_reg_s;\n")
+
+    # base
+    seen.clear()
+    for e in entries:
+        item = e['Item']
+        if item in seen:
+            continue
+        seen.add(item)
+        addr = e.get('Physical Address','0')
+        sub = addr[-3:]
+        base_entries.append(f"#define ANDLA_{item}_REG_BASE (ANDLA_REG_BASE + 0x{sub})\n")
+
+    # item enum & dest
+    seen.clear()
+    prev_id = None
+    for e in entries:
+        item = e['Item']
+        if item in seen:
+            continue
+        seen.add(item)
+        idv = int(e.get('ID',0))
+        if prev_id is not None and idv - prev_id > 1:
+            for i in range(prev_id+1, idv):
+                item_entries.append(f"   ,RESERVED_{i}")
+                dest_entries.append(f"#define RESERVED_{i}_DEST               (0x1 <<  {i})\n")
+        item_entries.append(f"   ,{item}")
+        dest_entries.append(f"#define {item}_DEST               (0x1 <<  {idv})\n")
+        prev_id = idv
+    item_entries.append(");\n")
+
+    # devreg/extreg
+    seen.clear()
+    for e in entries:
+        item = e['Item']
+        if item in seen:
+            continue
+        seen.add(item)
+        lc = item.lower()
+        uc = item.upper()
+        devreg_entries.append(f"#define DEV_ANDLA_{uc}_REG     ((andla_{lc}_reg_s*)      ANDLA_{uc}_REG_BASE  )\n")
+        extreg_entries.append(f"extern andla_{lc}_reg_s        *andla_{lc}_reg_p;\n")
+
+    return idx_entries, reg_entries, base_entries, dest_entries, item_entries, devreg_entries, extreg_entries
+
+
+def generate():
+    entries = load_log()
+    idx_entries, reg_entries, base_entries, dest_entries, item_entries, devreg_entries, extreg_entries = build_sections(entries)
+
+    with open(INPUT_FILE) as fin, open(OUTPUT_FILE, 'w') as fout:
+        idx_flag = reg_flag = base_flag = dest_flag = item_flag = False
+        dev_flag = ext_flag = False
+        for line in fin:
+            stripped = line.strip()
+            if stripped == '// autogen_idx_start':
+                fout.write(line)
+                for l in idx_entries:
+                    fout.write(l)
+                idx_flag = True
+                continue
+            if stripped == '// autogen_idx_stop':
+                idx_flag = False
+                fout.write(line)
+                continue
+            if stripped == '// autogen_reg_start':
+                fout.write(line)
+                for l in reg_entries:
+                    fout.write(l)
+                reg_flag = True
+                continue
+            if stripped == '// autogen_reg_stop':
+                reg_flag = False
+                fout.write(line)
+                continue
+            if stripped == '// autogen_base_start':
+                fout.write(line)
+                for l in base_entries:
+                    fout.write(l)
+                base_flag = True
+                continue
+            if stripped == '// autogen_base_stop':
+                base_flag = False
+                fout.write(line)
+                continue
+            if stripped == '// autogen_dest_start':
+                fout.write(line)
+                for l in dest_entries:
+                    fout.write(l)
+                dest_flag = True
+                continue
+            if stripped == '// autogen_dest_stop':
+                dest_flag = False
+                fout.write(line)
+                continue
+            if stripped == '// autogen_item_start':
+                fout.write(line)
+                for l in item_entries:
+                    fout.write(l + "\n" if not l.endswith('\n') else l)
+                item_flag = True
+                continue
+            if stripped == '// autogen_item_stop':
+                item_flag = False
+                fout.write(line)
+                continue
+            if stripped == '// autogen_devreg_start':
+                fout.write(line)
+                for l in devreg_entries:
+                    fout.write(l)
+                dev_flag = True
+                continue
+            if stripped == '// autogen_devreg_stop':
+                dev_flag = False
+                fout.write(line)
+                continue
+            if stripped == '// autogen_extreg_start':
+                fout.write(line)
+                for l in extreg_entries:
+                    fout.write(l)
+                ext_flag = True
+                continue
+            if stripped == '// autogen_extreg_stop':
+                ext_flag = False
+                fout.write(line)
+                continue
+            if not any([idx_flag, reg_flag, base_flag, dest_flag, item_flag, dev_flag, ext_flag]):
+                fout.write(line)
+
+if __name__ == '__main__':
+    generate()

--- a/gen_map.py
+++ b/gen_map.py
@@ -1,0 +1,59 @@
+import ast
+
+INPUT_FILE = 'input/regfile_map.tmp.h'
+OUTPUT_FILE = 'output/regfile_map.h'
+REG_LOG = 'output/regfile_dictionary.log'
+
+
+def load_log():
+    entries = []
+    with open(REG_LOG) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            line = line.replace('nan', 'None')
+            entries.append(ast.literal_eval(line))
+    return entries
+
+
+def build_dest(entries):
+    dest_entries = []
+    seen = set()
+    current_id = None
+    for e in entries:
+        item = e['Item']
+        if item in seen:
+            continue
+        seen.add(item)
+        item_id = int(e.get('ID',0))
+        if current_id is not None and item_id - current_id > 1:
+            for idx in range(current_id+1, item_id):
+                dest_entries.append(f"#define RESERVED_{idx}_DEST               (0x1 <<  {idx})\n")
+        dest_entries.append(f"#define {item}_DEST               (0x1 <<  {item_id})\n")
+        current_id = item_id
+    return dest_entries
+
+
+def generate():
+    entries = load_log()
+    dest_entries = build_dest(entries)
+    with open(INPUT_FILE) as fin, open(OUTPUT_FILE, 'w') as fout:
+        in_dest = False
+        for line in fin:
+            stripped = line.strip()
+            if stripped == '// autogen_dest_start':
+                fout.write(line)
+                in_dest = True
+                for d in dest_entries:
+                    fout.write(d)
+                continue
+            if stripped == '// autogen_dest_stop':
+                in_dest = False
+                fout.write(line)
+                continue
+            if not in_dest:
+                fout.write(line)
+
+if __name__ == '__main__':
+    generate()

--- a/gen_regfile.py
+++ b/gen_regfile.py
@@ -1,0 +1,53 @@
+import ast
+
+INPUT_FILE = 'input/andla_regfile.tmp.v'
+OUTPUT_FILE = 'output/andla_regfile.v'
+REG_LOG = 'output/regfile_dictionary.log'
+
+
+def load_log():
+    entries = []
+    with open(REG_LOG) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            line = line.replace('nan', 'None')
+            entries.append(ast.literal_eval(line))
+    return entries
+
+
+def list_ports(entries):
+    ports = []
+    seen = set()
+    for e in entries:
+        item = e['Item'].lower()
+        reg = e['Register'].lower()
+        if (item, reg) in seen:
+            continue
+        seen.add((item, reg))
+        ports.append(f"rf_{item}_{reg}")
+    return ports
+
+
+def generate():
+    entries = load_log()
+    ports = list_ports(entries)
+    with open(INPUT_FILE) as fin, open(OUTPUT_FILE, 'w') as fout:
+        in_port = False
+        for line in fin:
+            stripped = line.strip()
+            if stripped == '// autogen_port_start':
+                fout.write(line)
+                in_port = True
+                fout.write(', '.join(ports) + '\n')
+                continue
+            if stripped == '// autogen_port_stop':
+                in_port = False
+                fout.write(line)
+                continue
+            if not in_port:
+                fout.write(line)
+
+if __name__ == '__main__':
+    generate()

--- a/run.sh
+++ b/run.sh
@@ -2,10 +2,10 @@
 
 python3 csv2df.py
 python3 gen_vh.py
-perl gen_h.pl
-perl gen_common_h.pl
-perl gen_map.pl
-perl gen_regfile.pl
+python3 gen_h.py
+python3 gen_common_h.py
+python3 gen_map.py
+python3 gen_regfile.py
 python3 gen_reg_constraint_h.py
 
 # declare -A files=(


### PR DESCRIPTION
## Summary
- add Python versions of `gen_h`, `gen_common_h`, `gen_map` and `gen_regfile`
- switch `run.sh` to invoke the new Python scripts

## Testing
- `bash run.sh`

------
https://chatgpt.com/codex/tasks/task_e_686553c171548320a2adce87210fc1b1