### PR TITLE
Refactor gen_regfile with template-based writers

### DIFF
--- a/template_utils.py
+++ b/template_utils.py
@@ -1,0 +1,13 @@
+from typing import List
+
+
+def align_by_delimiter(lines: List[str], delimiter: str) -> List[str]:
+    """Align the left part of lines split by delimiter."""
+    parts = [line.split(delimiter, 1) for line in lines]
+    width = max(len(p[0]) for p in parts)
+    return [f"{p[0]:<{width}}{delimiter}{p[1]}" for p in parts]
+
+
+def zero_pad(value: int, width: int) -> str:
+    """Return zero filled string of given width."""
+    return str(value).zfill(width)

--- a/template_writer.py
+++ b/template_writer.py
@@ -1,0 +1,38 @@
+from typing import Iterable, Dict
+from jinja2 import Template
+
+
+class TemplateWriter:
+    """Base writer using Jinja2 templates for output generation."""
+
+    template_file: str = ""
+
+    def __init__(self, outfile, dict_lines):
+        self.outfile = outfile
+        self.lines = dict_lines
+        self._template_cache: Template | None = None
+
+    def load_template(self) -> Template:
+        if self._template_cache is None:
+            with open(self.template_file, "r") as f:
+                self._template_cache = Template(f.read())
+        return self._template_cache
+
+    # ---- Hooks to override ----
+    def records(self) -> Iterable[Dict[str, str]]:
+        for line in self.lines:
+            yield {}
+
+    def prepare_context(self, record: Dict[str, str]) -> Dict[str, str]:
+        return record
+
+    def postprocess(self, lines: Iterable[str]) -> Iterable[str]:
+        return lines
+
+    # ---------------------------
+
+    def write(self):
+        template = self.load_template()
+        rendered_lines = [template.render(**self.prepare_context(r)) for r in self.records()]
+        for line in self.postprocess(rendered_lines):
+            self.outfile.write(line)

--- a/templates/io.j2
+++ b/templates/io.j2
@@ -1,0 +1,1 @@
+{{ direction }}	[{{ bitwidth }}-1:0] {{ name }};

--- a/templates/reg.j2
+++ b/templates/reg.j2
@@ -1,0 +1,1 @@
+reg	[{{ bitwidth }}-1:0] {{ name }}_reg;


### PR DESCRIPTION
## Summary
- add `TemplateWriter` base class that renders Jinja2 templates
- add `template_utils` helpers for common formatting
- create simple templates under `templates/`
- refactor `IOWriter` and `RegWriter` to use the new base class

## Testing
- `python3 gen_regfile.py`

------
https://chatgpt.com/codex/tasks/task_e_68663bdf97848320ad7448d46602e139