### PR TITLE
Filter out NaN types in regfile generator

### DIFF
--- a/gen_regfile.py
+++ b/gen_regfile.py
@@ -58,9 +58,17 @@ class DictRow:
         return cls(item, register, subreg, typ, parsed_id, dv_str, data)
 
 def load_dictionary_lines():
-    """Read dictionary file and parse each line into DictRow objects."""
+    """Read dictionary file and parse each line into DictRow objects.
+
+    Any rows where the ``Type`` field evaluates to ``nan`` are ignored so
+    that subsequent generation stages do not process them.
+    """
     with open(dictionary_filename, 'r') as dict_fh:
-        return [DictRow.from_line(line.rstrip('\n')) for line in dict_fh]
+        rows = [DictRow.from_line(line.rstrip('\n')) for line in dict_fh]
+
+    # Filter out entries whose type is represented as ``nan``.  ``from_line``
+    # already lower-cases the value so a simple string comparison suffices.
+    return [row for row in rows if row.type != 'nan']
 
 
 class TemplateWriter:


### PR DESCRIPTION
## Summary
- skip dictionary entries where the `Type` field is `nan`

## Testing
- `bash run.sh` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python3 gen_regfile.py`

------
https://chatgpt.com/codex/tasks/task_e_6867b666f18483209c59344e681c764a