### PR TITLE
Refactor gen_regfile writer interfaces

### DIFF
--- a/gen_regfile.py
+++ b/gen_regfile.py
@@ -172,61 +172,53 @@ class BaseWriter(TemplateWriter):
 ########################################################################
 @register_writer("interrupt")
 class InterruptWriter(BaseWriter):
-    def write_interrupt(self):
+    def render(self):
         for key, _ in self.iter_items():
             if key in ('ldma2', 'csr'):
                 continue
-            self.outfile.write(f"                          ({key}_except & {key}_except_mask) |\n")
-
-    write = write_interrupt
+            yield f"                          ({key}_except & {key}_except_mask) |\n"
 
 ########################################################################
 # ExceptwireWriter
 ########################################################################
 @register_writer("exceptwire")
 class ExceptwireWriter(BaseWriter):
-    def write_exceptwire(self):
+    def render(self):
         for key, _ in self.iter_items():
             if key in ('ldma2', 'csr'):
                 continue
             uckey = key.upper()
-            self.outfile.write(f"wire {key}_except        = csr_status_reg[`{uckey}_ID + 8];\n")
-            self.outfile.write(f"wire {key}_except_mask   = csr_control_reg[`{uckey}_ID + 8];\n")
-
-    write = write_exceptwire
+            yield f"wire {key}_except        = csr_status_reg[`{uckey}_ID + 8];\n"
+            yield f"wire {key}_except_mask   = csr_control_reg[`{uckey}_ID + 8];\n"
 
 ########################################################################
 # ExceptioWriter
 ########################################################################
 @register_writer("exceptio")
 class ExceptioWriter(BaseWriter):
-    def write_exceptio(self):
+    def render(self):
         for key, _ in self.iter_items():
             if key in ('ldma2', 'csr'):
                 continue
-            self.outfile.write(f"input                 rf_{key}_except_trigger;\n")
-
-    write = write_exceptio
+            yield f"input                 rf_{key}_except_trigger;\n"
 
 ########################################################################
 # ExceptportWriter
 ########################################################################
 @register_writer("exceptport")
 class ExceptportWriter(BaseWriter):
-    def write_exceptport(self):
+    def render(self):
         for key, _ in self.iter_items():
             if key in ('ldma2', 'csr'):
                 continue
-            self.outfile.write(f",rf_{key}_except_trigger\n")
-
-    write = write_exceptport
+            yield f",rf_{key}_except_trigger\n"
 
 ########################################################################
 # RiurwaddrWriter
 ########################################################################
 @register_writer("riurwaddr")
 class RiurwaddrWriter(ZeroFillMixin, BaseWriter):
-    def render_riurwaddr(self):
+    def render(self):
         output = []
         prev_id = None
         for key, value in self.iter_items():
@@ -240,14 +232,13 @@ class RiurwaddrWriter(ZeroFillMixin, BaseWriter):
             prev_id = value
         return output
 
-    render = render_riurwaddr
 
 ########################################################################
 # StatusnxWriter
 ########################################################################
 @register_writer("statusnx")
 class StatusnxWriter(ZeroFillMixin, BaseWriter):
-    def render_statusnx(self):
+    def render(self):
         items = list(self.iter_items())
         
         output = []
@@ -276,14 +267,13 @@ class StatusnxWriter(ZeroFillMixin, BaseWriter):
             prev_id = value
         return output
 
-    render = render_statusnx
 
 ########################################################################
 # SfenceenWriter
 ########################################################################
 @register_writer("sfenceen")
 class SfenceenWriter(ZeroFillMixin, BaseWriter):
-    def render_sfenceen(self):
+    def render(self):
         output = []
         prev_id = None
         for key, value in self.iter_items():
@@ -300,14 +290,13 @@ class SfenceenWriter(ZeroFillMixin, BaseWriter):
             prev_id = value
         return output
 
-    render = render_sfenceen
 
 ########################################################################
 # ScoreboardWriter
 ########################################################################
 @register_writer("scoreboard")
 class ScoreboardWriter(ZeroFillMixin, BaseWriter):
-    def render_scoreboard(self):
+    def render(self):
         output = []
         prev_id = None
         for key, value in self.iter_items():
@@ -322,52 +311,45 @@ class ScoreboardWriter(ZeroFillMixin, BaseWriter):
             prev_id = value
         return output
 
-    render = render_scoreboard
 
 ########################################################################
 # BaseaddrselbitwidthWriter
 ########################################################################
 @register_writer("baseaddrselbitwidth")
 class BaseaddrselbitwidthWriter(BaseWriter):
-    def write_baseaddrselbitwidth(self):
+    def render(self):
         for keys in self.iter_dma_items():
             uckeys = keys.upper()
-            self.outfile.write(f"localparam {uckeys}_BASE_ADDR_SELECT_BITWIDTH = 3;\n")
-
-    write = write_baseaddrselbitwidth
+            yield f"localparam {uckeys}_BASE_ADDR_SELECT_BITWIDTH = 3;\n"
 
 ########################################################################
 # BaseaddrselioWriter
 ########################################################################
 @register_writer("baseaddrselio")
 class BaseaddrselioWriter(BaseWriter):
-    def write_baseaddrselio(self):
+    def render(self):
         for keys in self.iter_dma_items():
             uckeys = keys.upper()
-            self.outfile.write(f"output [{uckeys}_BASE_ADDR_SELECT_BITWIDTH-           1:0] {keys}_base_addr_select;\n")
-
-    write = write_baseaddrselio
+            yield f"output [{uckeys}_BASE_ADDR_SELECT_BITWIDTH-           1:0] {keys}_base_addr_select;\n"
 
 ########################################################################
 # BaseaddrselportWriter
 ########################################################################
 @register_writer("baseaddrselport")
 class BaseaddrselportWriter(BaseWriter):
-    def write_baseaddrselport(self):
+    def render(self):
         for keys in self.iter_dma_items():
-            self.outfile.write(f",{keys}_base_addr_select\n")
-
-    write = write_baseaddrselport
+            yield f",{keys}_base_addr_select\n"
 
 ########################################################################
 # BaseaddrselWriter
 ########################################################################
 @register_writer("baseaddrsel")
 class BaseaddrselWriter(BaseWriter):
-    def write_baseaddrsel(self):
+    def render(self):
         for keys in self.iter_dma_items():
             uckeys = keys.upper()
-            self.outfile.write(
+            yield (
 f"""
 wire [{uckeys}_BASE_ADDR_SELECT_BITWIDTH-1:0] {keys}_base_addr_select_nx;
 assign  {keys}_base_addr_select_nx           = {keys}_sfence_nx[20:18];
@@ -381,8 +363,6 @@ wire [3-1: 0] {keys}_base_addr_select;
 assign {keys}_base_addr_select            = {keys}_base_addr_select_reg;\n\n"""
             )
 
-    write = write_baseaddrsel
-
 ########################################################################
 # SfenceWriter
 ########################################################################
@@ -392,14 +372,14 @@ class SfenceWriter(BaseWriter):
         super().__init__(outfile, dict_lines)
         self.seen_sfence = {}
 
-    def write_sfence(self):
+    def render(self):
         for row in self.lines:
             item = row.item
             register = row.register
             if item and register == 'sfence':
                 self.seen_sfence[item] = 1
         for keys in self.seen_sfence:
-            self.outfile.write(
+            yield (
 f"""wire {keys}_start_reg_nx = wr_taken & {keys}_sfence_en;
 reg  {keys}_start_reg;
 wire {keys}_start_reg_en = {keys}_start_reg ^ {keys}_start_reg_nx;
@@ -410,8 +390,6 @@ end
 assign rf_{keys}_sfence = {keys}_start_reg;\n\n"""
             )
 
-    write = write_sfence
-
 ########################################################################
 # IpnumWriter
 ########################################################################
@@ -421,15 +399,13 @@ class IpnumWriter(BaseWriter):
         super().__init__(outfile, dict_lines)
         self.seen_items = {}
 
-    def write_ipnum(self):
+    def render(self):
         for row in self.lines:
             item = row.item
             if item and item not in self.seen_items:
                 self.seen_items[item] = 1
         # 與原 Perl 保持一致：直接輸出 ITEM_ID_NUM 巨集
-        self.outfile.write("localparam ITEM_ID_NUM = `ITEM_ID_NUM;\n")
-
-    write = write_ipnum
+        yield "localparam ITEM_ID_NUM = `ITEM_ID_NUM;\n"
 
 ########################################################################
 # PortWriter
@@ -440,7 +416,7 @@ class PortWriter(BaseWriter):
         super().__init__(outfile, dict_lines)
         self.seen_items = {}
 
-    def write_port(self):
+    def render(self):
         for row in self.lines:
             item = row.item
             register = row.register
@@ -456,10 +432,8 @@ class PortWriter(BaseWriter):
             key = f"{item}_{register}"
             if key in self.seen_items:
                 continue
-            self.outfile.write(f", rf_{item}_{register}\n")
+            yield f", rf_{item}_{register}\n"
             self.seen_items[key] = 1
-
-    write = write_port
 
 ########################################################################
 # BitwidthWriter
@@ -485,7 +459,7 @@ class BitwidthWriter(AlignMixin, BaseWriter):
         self.subregister = row.subregister.upper() if row.subregister else ''
         self.key         = f"{self.item}_{self.register}"
 
-    def render_bitwidth(self):
+    def render(self):
         for row in self.lines:
             self.fetch_terms(row)
             if self.subregister:
@@ -516,7 +490,6 @@ class BitwidthWriter(AlignMixin, BaseWriter):
             pairs.append((left.strip(), right.strip()))
         return self.align_pairs(pairs, ' = ')
 
-    render = render_bitwidth
 
 ########################################################################
 # IOWriter
@@ -559,7 +532,7 @@ class IOWriter(AlignMixin, BaseWriter):
                 self.io_lines.append(f"output\t [{self.item.upper()}_{self.register.upper()}_BITWIDTH-1:0] rf_{self.item}_{self.register};")
         self.seen_items[self.key] = 1
 
-    def render_io(self):
+    def render(self):
         for row in self.lines:
                 self.fetch_terms(row)
                 self._process()
@@ -570,7 +543,6 @@ class IOWriter(AlignMixin, BaseWriter):
             pairs.append((left, right))
         return self.align_pairs(pairs, '\t')
 
-    render = render_io
 
 ########################################################################
 # RegWriter
@@ -598,7 +570,7 @@ class RegWriter(AlignMixin, BaseWriter):
     def _skip(self):
         return self.typ != 'rw'
 
-    def render_reg(self):
+    def render(self):
         for row in self.lines:
             self.fetch_terms(row)
             if self._skip():
@@ -619,7 +591,6 @@ class RegWriter(AlignMixin, BaseWriter):
             pairs.append((left + ']', right))
         return self.align_pairs(pairs, '\t')
 
-    render = render_reg
 
 ########################################################################
 # WireNxWriter
@@ -657,7 +628,7 @@ class WireNxWriter(AlignMixin, BaseWriter):
         self.seen_items[self.key] = 1
         return False
 
-    def render_wire_nx(self):
+    def render(self):
         for row in self.lines:
             self.fetch_terms(row)
             if self._skip():
@@ -676,7 +647,6 @@ class WireNxWriter(AlignMixin, BaseWriter):
             pairs.append((left + ']', right))
         return self.align_pairs(pairs, '   ')
 
-    render = render_wire_nx
 
 ########################################################################
 # WireEnWriter
@@ -710,7 +680,7 @@ class WireEnWriter(BaseWriter):
             self.seen_items[self.key] = 1
         return False
 
-    def render_wire_en(self):
+    def render(self):
         self.seen_items = {}
         for row in self.lines:
                 self.fetch_terms(row)
@@ -723,7 +693,6 @@ class WireEnWriter(BaseWriter):
                     self.wire_name = f"{self.item}_{self.register}_en"
                 yield f"wire   {self.wire_name};\n"
 
-    render = render_wire_en
 
 ########################################################################
 # SeqWriter
@@ -756,7 +725,7 @@ class SeqWriter(BaseWriter):
         return False
 
 
-    def render_seq(self):
+    def render(self):
         output = []
         output.append("always @(posedge clk or negedge rst_n) begin\n")
         output.append("    if(~rst_n) begin\n")
@@ -792,7 +761,6 @@ class SeqWriter(BaseWriter):
         output.append("end\n")
         return output
 
-    render = render_seq
 
 ########################################################################
 # EnWriter
@@ -824,7 +792,7 @@ class EnWriter(AlignMixin, BaseWriter):
         self.seen_items[self.key] = 1
         return False
 
-    def render_en(self):
+    def render(self):
         for row in self.lines:
                 self.fetch_term(row)
                 if self._skip():
@@ -841,7 +809,6 @@ class EnWriter(AlignMixin, BaseWriter):
                 right= assignment[len(left):]
                 yield from self.align_pairs([(left, right)], '')
 
-    render = render_en
 
 ########################################################################
 # NxWriter
@@ -886,7 +853,7 @@ class NxWriter(AlignMixin, BaseWriter):
         else:
             self.assignments.append(f"assign {self.item}_{self.register}_nx = {{ {{ (32 - {self.register.upper()}_DATA.bit_length()) {{ 1'b0 }} }}, {self.register.upper()}_DATA}};")
 
-    def render_nx(self):
+    def render(self):
         for row in self.lines:
             self.fetch_terms(row)
             if self.typ == 'ro' and self.register:
@@ -935,7 +902,6 @@ class NxWriter(AlignMixin, BaseWriter):
             pairs.append((left.strip(), right.strip()))
         return self.align_pairs(pairs, ' = ')
 
-    render = render_nx
 
 ########################################################################
 # CTRLWriter
@@ -975,7 +941,7 @@ class CTRLWriter(AlignMixin, BaseWriter):
         return f"\t\t\t\t  ({{RF_RDATA_BITWIDTH{{({signal_name})}}}} & {{{{(RF_RDATA_BITWIDTH-{bitwidth}){{1'b0}}}}, {reg_name}}}) |"
 
 
-    def render_control(self):
+    def render(self):
         output = ["assign issue_rf_riurdata =\n"]
         for row in self.lines:
             self.fetch_terms(row)
@@ -1004,7 +970,6 @@ class CTRLWriter(AlignMixin, BaseWriter):
         output.extend(self.align_pairs(pairs, ''))
         return output
 
-    render = render_control
 
 ########################################################################
 # OutputWriter
@@ -1063,7 +1028,7 @@ class OutputWriter(AlignMixin, BaseWriter):
         else:
             self.bitwidth_lines.append(f"assign rf_{self.item}_{self.register} = {self.item}_{self.register}_reg;")
 
-    def render_output(self):
+    def render(self):
         for row in self.lines:
                 self.fetch_terms(row)
                 if self.register:
@@ -1075,7 +1040,6 @@ class OutputWriter(AlignMixin, BaseWriter):
             pairs.append((left.strip(), right.strip()))
         return self.align_pairs(pairs, ' = ')
 
-    render = render_output
 
 # The list of writers is now populated automatically via @register_writer.
 


### PR DESCRIPTION
## Summary
- standardize writer classes in `gen_regfile.py` to implement `render()`
- drop `render_xxx` and `write_xxx` aliases
- mixins remain focused on alignment and zero-fill utilities

## Testing
- `python3 -m py_compile gen_regfile.py`

------
https://chatgpt.com/codex/tasks/task_e_6867c02da0988320a39e9559fc744fad