### PR TITLE
Fix filtering of csr and ldma2

### DIFF
--- a/gen_regfile.py
+++ b/gen_regfile.py
@@ -246,8 +246,10 @@ class GenericTemplateWriter(RegistryMixin, TemplateItemWriter):
             cls._iter_fn = TemplateItemWriter.iter_items
 
     def render(self):
-        for item in self._iter_fn(self):
+        for item in self._iter_fn():
             _item = item[0] if isinstance(item, tuple) else item
+            if _item in getattr(self, "skip_items", set()):
+                continue
             ctx = {"item": _item, "item_upper": _item.upper()}
             for tmpl in self.templates:
                 yield self.render_template(tmpl, ctx)
@@ -287,25 +289,25 @@ class RowTemplateWriter(RowMixin, BaseWriter):
 # InterruptWriter
 ########################################################################
 class InterruptWriter(GenericTemplateWriter, key="interrupt"):
-    pass
+    skip_items = {"ldma2", "csr"}
 
 ########################################################################
 # ExceptwireWriter
 ########################################################################
 class ExceptwireWriter(GenericTemplateWriter, key="exceptwire"):
-    pass
+    skip_items = {"ldma2", "csr"}
 
 ########################################################################
 # ExceptioWriter
 ########################################################################
 class ExceptioWriter(GenericTemplateWriter, key="exceptio"):
-    pass
+    skip_items = {"ldma2", "csr"}
 
 ########################################################################
 # ExceptportWriter
 ########################################################################
 class ExceptportWriter(GenericTemplateWriter, key="exceptport"):
-    pass
+    skip_items = {"ldma2", "csr"}
 
 ########################################################################
 # RiurwaddrWriter


### PR DESCRIPTION
## Summary
- skip `csr` and `ldma2` in four interrupt-related template writers
- ensure `GenericTemplateWriter` filters items correctly
- fix call to iterator method
- regenerate `output/andla_regfile.v`

## Testing
- `python3 gen_regfile.py`

------
https://chatgpt.com/codex/tasks/task_e_6868f9078e0883209611f784b88651da