### PR TITLE
Refactor regfile writers to jinja templates

### DIFF
--- a/regfile_templates/baseaddrsel.j2
+++ b/regfile_templates/baseaddrsel.j2
@@ -1,0 +1,13 @@
+{% for b in blocks %}
+wire [{{ b.upper }}_BASE_ADDR_SELECT_BITWIDTH-1:0] {{ b.key }}_base_addr_select_nx;
+assign  {{ b.key }}_base_addr_select_nx           = {{ b.key }}_sfence_nx[20:18];
+wire {{ b.key }}_base_addr_select_en           = wr_taken & {{ b.key }}_sfence_en;
+reg  [{{ b.upper }}_BASE_ADDR_SELECT_BITWIDTH-1:0] {{ b.key }}_base_addr_select_reg;
+always @(posedge clk or negedge rst_n) begin
+    if (~rst_n)                        {{ b.key }}_base_addr_select_reg <= {{ b.zero }};
+    else if ({{ b.key }}_base_addr_select_en) {{ b.key }}_base_addr_select_reg <= {{ b.key }}_base_addr_select_nx;
+end
+wire [3-1: 0] {{ b.key }}_base_addr_select;
+assign {{ b.key }}_base_addr_select            = {{ b.key }}_base_addr_select_reg;
+
+{% endfor %}

--- a/regfile_templates/bitwidth.j2
+++ b/regfile_templates/bitwidth.j2
@@ -1,0 +1,3 @@
+{% for left, right in pairs %}
+{{ left | ljust(max_len) }} = {{ right }}
+{% endfor %}

--- a/regfile_templates/control.j2
+++ b/regfile_templates/control.j2
@@ -1,0 +1,5 @@
+assign issue_rf_riurdata =
+{% for left, right in pairs %}
+{{ left | ljust(max_len) }}{{ right }}
+{% endfor %}
+;

--- a/regfile_templates/en.j2
+++ b/regfile_templates/en.j2
@@ -1,0 +1,3 @@
+{% for left, right in pairs %}
+{{ left | ljust(max_len) }} = {{ right }}
+{% endfor %}

--- a/regfile_templates/io.j2
+++ b/regfile_templates/io.j2
@@ -1,0 +1,3 @@
+{% for left, right in pairs %}
+{{ left | ljust(max_len) }}\t{{ right }}
+{% endfor %}

--- a/regfile_templates/nx.j2
+++ b/regfile_templates/nx.j2
@@ -1,0 +1,3 @@
+{% for left, right in pairs %}
+{{ left | ljust(max_len) }} = {{ right }}
+{% endfor %}

--- a/regfile_templates/output.j2
+++ b/regfile_templates/output.j2
@@ -1,0 +1,3 @@
+{% for left, right in pairs %}
+{{ left | ljust(max_len) }} = {{ right }}
+{% endfor %}

--- a/regfile_templates/port.j2
+++ b/regfile_templates/port.j2
@@ -1,0 +1,3 @@
+{% for p in ports %}
+, rf_{{ p.item }}_{{ p.register }}
+{% endfor %}

--- a/regfile_templates/reg.j2
+++ b/regfile_templates/reg.j2
@@ -1,0 +1,3 @@
+{% for left, right in pairs %}
+{{ left | ljust(max_len) }}\t{{ right }}
+{% endfor %}

--- a/regfile_templates/riurwaddr.j2
+++ b/regfile_templates/riurwaddr.j2
@@ -1,0 +1,10 @@
+{% for e in entries %}
+{% for idx in e.zeros %}
+wire riurwaddr_bit{{ idx }}                      = 1'b0;
+{% endfor %}
+{% if e.key == 'csr' %}
+wire riurwaddr_bit{{ e.id }}                      = 1'b0;
+{% else %}
+wire riurwaddr_bit{{ e.id }}                      = (issue_rf_riurwaddr[(RF_ADDR_BITWIDTH-1) -: ITEM_ID_BITWIDTH] == `{{ e.uckey }}_ID);
+{% endif %}
+{% endfor %}

--- a/regfile_templates/scoreboard.j2
+++ b/regfile_templates/scoreboard.j2
@@ -1,0 +1,10 @@
+{% for e in entries %}
+{% for idx in e.zeros %}
+assign scoreboard[{{ idx }}]               = 1'b0;
+{% endfor %}
+{% if e.key == 'csr' %}
+assign scoreboard[{{ e.id }}]               = (ip_rf_status_clr[0]) ? 1'b0 : csr_status_reg[0];
+{% else %}
+assign scoreboard[{{ e.id }}]               = (ip_rf_status_clr[`{{ e.uckey }}_ID]) ? 1'b0 : csr_status_reg[`{{ e.uckey }}_ID];
+{% endif %}
+{% endfor %}

--- a/regfile_templates/seq.j2
+++ b/regfile_templates/seq.j2
@@ -1,0 +1,11 @@
+always @(posedge clk or negedge rst_n) begin
+    if(~rst_n) begin
+{% for line in init_lines %}
+{{ line }}
+{% endfor %}
+    end else begin
+{% for r in reg_names %}
+        {{ r.reg | ljust(max_len) }} <= {{ r.wire }};
+{% endfor %}
+    end
+end

--- a/regfile_templates/sfence.j2
+++ b/regfile_templates/sfence.j2
@@ -1,0 +1,11 @@
+{% for k in items %}
+wire {{ k }}_start_reg_nx = wr_taken & {{ k }}_sfence_en;
+reg  {{ k }}_start_reg;
+wire {{ k }}_start_reg_en = {{ k }}_start_reg ^ {{ k }}_start_reg_nx;
+always @(posedge clk or negedge rst_n) begin
+    if (~rst_n) {{ k }}_start_reg <= 1'b0;
+    else if ({{ k }}_start_reg_en) {{ k }}_start_reg <= {{ k }}_start_reg_nx;
+end
+assign rf_{{ k }}_sfence = {{ k }}_start_reg;
+
+{% endfor %}

--- a/regfile_templates/sfenceen.j2
+++ b/regfile_templates/sfenceen.j2
@@ -1,0 +1,12 @@
+{% for e in entries %}
+{% for idx in e.zeros %}
+               1'b0,
+{% endfor %}
+{% if e.key == 'csr' %}
+               1'b0
+{% elif e.key == 'ldma2' %}
+               1'b0,
+{% else %}
+               {{ e.key }}_sfence_en,
+{% endif %}
+{% endfor %}

--- a/regfile_templates/statusnx.j2
+++ b/regfile_templates/statusnx.j2
@@ -1,0 +1,22 @@
+{% for e in first %}
+{% for idx in e.zeros %}
+assign csr_status_nx[{{ idx }}]                = 1'b0;
+{% endfor %}
+{% if e.key == 'csr' %}
+assign csr_status_nx[0]                = (wr_taken & sfence_en[0]  ) ? 1'b1 : scoreboard[0];
+{% else %}
+assign csr_status_nx[`{{ e.uckey }}_ID]         = (wr_taken & sfence_en[`{{ e.uckey }}_ID]  ) ? 1'b1 : scoreboard[`{{ e.uckey }}_ID];
+{% endif %}
+{% endfor %}
+{% for e in second %}
+{% for idx in e.zeros %}
+assign csr_status_nx[{{ idx }} + 8]                = 1'b0;
+{% endfor %}
+{% if e.typ == 'csr' %}
+assign csr_status_nx[8]                           = 1'b0;
+{% elif e.typ == 'ldma2' %}
+assign csr_status_nx[`{{ e.uckey }}_ID + 8]                = rf_ldma_except_trigger ? 1'b1 : (wr_taken & csr_status_en) ? issue_rf_riuwdata[`{{ e.uckey }}_ID + 8] : csr_status_reg[`{{ e.uckey }}_ID + 8];
+{% else %}
+assign csr_status_nx[`{{ e.uckey }}_ID + 8]                = rf_{{ e.key }}_except_trigger ? 1'b1 : (wr_taken & csr_status_en) ? issue_rf_riuwdata[`{{ e.uckey }}_ID + 8] : csr_status_reg[`{{ e.uckey }}_ID + 8];
+{% endif %}
+{% endfor %}

--- a/regfile_templates/wire_en.j2
+++ b/regfile_templates/wire_en.j2
@@ -1,0 +1,3 @@
+{% for name in names %}
+wire   {{ name }};
+{% endfor %}

--- a/regfile_templates/wire_nx.j2
+++ b/regfile_templates/wire_nx.j2
@@ -1,0 +1,3 @@
+{% for left, right in pairs %}
+{{ left | ljust(max_len) }}   {{ right }}
+{% endfor %}


### PR DESCRIPTION
## Summary
- replace f-string assembly with Jinja2 templating
- add new `regfile_templates` for each writer
- introduce `JinjaTemplateWriter` base class and environment

## Testing
- `python3 gen_regfile.py`

------
https://chatgpt.com/codex/tasks/task_e_68693e8c70d4832099dffd2639111f61