### PR TITLE
Move helper utilities to utils

### DIFF
--- a/gen_regfile.py
+++ b/gen_regfile.py
@@ -1,100 +1,16 @@
 #!/usr/bin/env python3
 
-import os
 import re
-import ast
-import math
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
+
+from utils import DictRow, WRITER_MAP, load_dictionary_lines, register_writer
 
 # File path configuration
 input_filename       = 'input/andla_regfile.tmp.v'
 output_filename      = 'output/andla_regfile.v'
 dictionary_filename  = 'output/regfile_dictionary.log'
 
-@dataclass
-class DictRow:
-    item: str = ''
-    register: str = ''
-    subregister: str = ''
-    type: str = ''
-    id: int | None = None
-    default_value: str = ''
-    raw: dict = None
 
-    @staticmethod
-    def _normalize_str(value, *, lower: bool = True) -> str:
-        """Return a string with NaN/``None`` converted to ``''`` and optional
-        case folding."""
-
-        if value is None or (isinstance(value, float) and math.isnan(value)):
-            return ''
-        result = str(value)
-        return result.lower() if lower else result
-
-    @staticmethod
-    def _normalize_int(value) -> int | None:
-        """Return ``None`` when ``value`` is NaN/``None`` otherwise ``int``."""
-
-        if value is None or (isinstance(value, float) and math.isnan(value)):
-            return None
-        return int(value)
-
-    @classmethod
-    def from_line(cls, line: str) -> "DictRow":
-        """Parse a log line into a ``DictRow`` instance using ``ast.literal_eval``.
-
-        The log file may contain bare ``nan`` tokens which are not valid Python
-        literals.  These are converted to ``None`` prior to parsing so that
-        ``ast.literal_eval`` can safely evaluate the string.
-        """
-
-        # Replace unquoted ``nan`` tokens with ``None`` for safe parsing
-        safe_line = re.sub(r':\s*nan\b(\s*[,}])', r': None\1', line)
-        safe_line = re.sub(r':\s*nan\s*$', ': None', safe_line)
-        data = ast.literal_eval(safe_line)
-        return cls(
-            cls._normalize_str(data.get('Item')),
-            cls._normalize_str(data.get('Register')),
-            cls._normalize_str(data.get('SubRegister')),
-            cls._normalize_str(data.get('Type')),
-            cls._normalize_int(data.get('ID')),
-            cls._normalize_str(data.get('Default Value'), lower=False),
-            data,
-        )
-
-def load_dictionary_lines():
-    """Read dictionary file and parse each line into DictRow objects.
-
-    Any rows where the ``Type`` field evaluates to ``nan`` are ignored so
-    that subsequent generation stages do not process them.
-    """
-    with open(dictionary_filename, 'r') as dict_fh:
-        rows = [DictRow.from_line(line.rstrip('\n')) for line in dict_fh]
-
-    # Filter out entries whose type is represented as ``nan``.  ``from_line``
-    # already lower-cases the value so a simple string comparison suffices.
-    return [row for row in rows if row.type != '']
-
-# ---------------------------------------------------------------------------
-# Writer registration helpers
-# ---------------------------------------------------------------------------
-
-# Registry of writer name to class mappings. Populated via ``register_writer``
-# decorator applied to each writer class.  ``dict`` preserves insertion order on
-# Python 3.7+, ensuring deterministic writer ordering.
-WRITER_MAP: dict[str, type] = {}
-
-
-def register_writer(name: str) -> Callable[[type], type]:
-    """Class decorator used to register ``BaseWriter`` subclasses."""
-
-    def decorator(cls: type) -> type:
-        WRITER_MAP[name] = cls
-        return cls
-
-    return decorator
 
 class BaseWriter:
     """
@@ -907,7 +823,7 @@ def gen_regfile():
 
     # Prepare writer instances and regex patterns
     patterns = {key: re.compile(rf'^// autogen_{key}_start') for key in WRITER_MAP}
-    dict_lines = load_dictionary_lines()
+    dict_lines = load_dictionary_lines(dictionary_filename)
     writers = {key: cls(None, dict_lines) for key, cls in WRITER_MAP.items()}
     found = {key: False for key in WRITER_MAP}
 

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Utility functions and helpers for code generation."""
+
+import ast
+import math
+import re
+from dataclasses import dataclass
+from typing import Callable
+
+# Registry of writer name to class mappings.
+WRITER_MAP: dict[str, type] = {}
+
+@dataclass
+class DictRow:
+    """Normalized representation of a dictionary log entry."""
+
+    item: str = ''
+    register: str = ''
+    subregister: str = ''
+    type: str = ''
+    id: int | None = None
+    default_value: str = ''
+    raw: dict | None = None
+
+    @staticmethod
+    def _normalize_str(value, *, lower: bool = True) -> str:
+        """Return a string with NaN/``None`` converted to ``''``."""
+
+        if value is None or (isinstance(value, float) and math.isnan(value)):
+            return ''
+        result = str(value)
+        return result.lower() if lower else result
+
+    @staticmethod
+    def _normalize_int(value) -> int | None:
+        """Return ``None`` when ``value`` is NaN/``None`` otherwise ``int``."""
+
+        if value is None or (isinstance(value, float) and math.isnan(value)):
+            return None
+        return int(value)
+
+    @classmethod
+    def from_line(cls, line: str) -> "DictRow":
+        """Parse a log line into a ``DictRow`` instance."""
+
+        safe_line = re.sub(r':\s*nan\b(\s*[,}])', r': None\1', line)
+        safe_line = re.sub(r':\s*nan\s*$', ': None', safe_line)
+        data = ast.literal_eval(safe_line)
+        return cls(
+            cls._normalize_str(data.get('Item')),
+            cls._normalize_str(data.get('Register')),
+            cls._normalize_str(data.get('SubRegister')),
+            cls._normalize_str(data.get('Type')),
+            cls._normalize_int(data.get('ID')),
+            cls._normalize_str(data.get('Default Value'), lower=False),
+            data,
+        )
+
+
+def load_dictionary_lines(dictionary_filename: str):
+    """Read dictionary file and parse each line into :class:`DictRow` objects."""
+
+    with open(dictionary_filename, 'r') as dict_fh:
+        rows = [DictRow.from_line(line.rstrip('\n')) for line in dict_fh]
+
+    return [row for row in rows if row.type != '']
+
+
+def register_writer(name: str) -> Callable[[type], type]:
+    """Class decorator used to register ``BaseWriter`` subclasses."""
+
+    def decorator(cls: type) -> type:
+        WRITER_MAP[name] = cls
+        return cls
+
+    return decorator


### PR DESCRIPTION
## Summary
- extract `DictRow`, `load_dictionary_lines` and `register_writer` into a new `utils.py`
- update `gen_regfile.py` to use the new helpers

## Testing
- `python3 -m py_compile gen_regfile.py utils.py`
- `python3 gen_regfile.py > /tmp/gen_regfile.out`

------
https://chatgpt.com/codex/tasks/task_e_686b1e235a348320a68521b501a18205